### PR TITLE
Added deployment file for two arm raw traffic

### DIFF
--- a/deployments/raw-two-arm.k8s.yaml
+++ b/deployments/raw-two-arm.k8s.yaml
@@ -1,0 +1,152 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ixia-c-two-arm-svc
+spec:
+  type: NodePort
+  selector:
+    app: ixia-c-two-arm
+  ports:
+  - name: controller
+    protocol: TCP
+    port: 443
+    targetPort: 443
+    nodePort: 30003
+  - name: traffic-engine-1
+    protocol: TCP
+    port: 5555
+    targetPort: 5555
+    nodePort: 30005
+  - name: traffic-engine-2
+    protocol: TCP
+    port: 5556
+    targetPort: 5555
+    nodePort: 30006
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ixia-c-controller
+  labels:
+    app: ixia-c-two-arm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ixia-c-two-arm
+  template:
+    metadata:
+      labels:
+        app: ixia-c-two-arm
+    spec:
+      containers:
+      - name: ixia-c-controller
+        image: ixiacom/ixia-c-controller:latest
+        args:
+          - --accept-eula
+          - --log-out
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 250m
+          limits:
+            memory: 4Gi
+            cpu: 1000m
+        ports:
+        - containerPort: 443
+          protocol: TCP
+
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ixia-c-traffic-engine-1
+  labels:
+    app: ixia-c-two-arm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ixia-c-two-arm
+  template:
+    metadata:
+      labels:
+        app: ixia-c-two-arm
+    spec:
+      containers:
+      - name: ixia-c-traffic-engine-1
+        image: ixiacom/ixia-c-traffic-engine:latest
+        env:
+          - name: OPT_LISTEN_PORT
+            value: "5555"
+          - name: ARG_IFACE_LIST
+            value: virtual@af_packet,eth0
+          - name: OPT_NO_HUGEPAGES
+            value: "Yes"
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 250m
+          limits:
+            memory: 4Gi
+            cpu: 3000m
+        ports:
+        - containerPort: 5555
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - NET_ADMIN
+              - IPC_LOCK
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ixia-c-traffic-engine-2
+  labels:
+    app: ixia-c-two-arm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ixia-c-two-arm
+  template:
+    metadata:
+      labels:
+        app: ixia-c-two-arm
+    spec:
+      containers:
+      - name: ixia-c-traffic-engine-2
+        image: ixiacom/ixia-c-traffic-engine:latest
+        env:
+          - name: OPT_LISTEN_PORT
+            value: "5555"
+          - name: ARG_IFACE_LIST
+            value: virtual@af_packet,eth0
+          - name: OPT_NO_HUGEPAGES
+            value: "Yes"
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 250m
+          limits:
+            memory: 4Gi
+            cpu: 3000m
+        ports:
+        - containerPort: 5555
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - NET_ADMIN
+              - IPC_LOCK


### PR DESCRIPTION
## How To

- Setup a minimal k8s cluster: https://k3s.io/
- Deploy (might need sudo for kubectl)
  ```bash
  kubectl deploy -f ixia-c/deployments/raw-two-arm.k8s.yaml
  # ensure all pods are up (and note IP if needed)
  kubectl get pods -o wide
  # note cluster IP if needed
  kubectl get services
  ```
- Modify ixia-c/snappi-tests/scripts/hello_snappi.py to include following api and port location:
  ```python
    # 30003 port is internally mapped to 443 port of controller pod (via cluster IP port 443)
    api = snappi.api(host='https://node-host-name:30003')
    cfg = api.config()

    # 30005 and 30006 ports are internally mapped to port 5555 of both traffic engine pod (via cluster IP ports 5555 and 5556)
    p1, p2 = (
        cfg.ports
        .port(name='p1', location='node-host-name:30005')
        .port(name='p2', location='node-host-name:30006')
    )

  ```
- Run the script
  ```bash
  python -W ignore ixia-c/snappi-tests/scripts/hello_snappi.py
  ```

## First Impressions

- Had to provide capabilities and bind to interface created inside the container (eth0). Need to check how we can bind to host interface.
- Controller was refusing connection quite often (maybe because of low k8s components hogging up the resources)
- tx rate was ok, but rx rate was really slow (No specific cores were provided)

## Pending Items

- Add to readme if approved
- Might want to replace docker-compose commands if approved
